### PR TITLE
Feature/fr translation corrections

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,13 +1,13 @@
-Bienvenue dans la FFmpeg School of Assembly Language. Vous avez fait le premier pas dans le voyage le plus intéressant, le plus stimulant et le plus gratifiant de la programmation. Ces leçons vous donneront des bases sr la façon sur la manière l'assembleur est utilisée dans FFmpeg et vous ouvriront les yeux sur ce qui se passe réellement à l'intérieur de votre ordinateur...
+Bienvenue dans la FFmpeg School of Assembly Language. Vous avez fait le premier pas dans le voyage le plus intéressant, le plus stimulant et le plus gratifiant de la programmation. Ces leçons vous donneront des bases sur la façon et la manière dont l'assembleur est utilisée dans FFmpeg et vous ouvriront les yeux sur ce qui se passe réellement à l'intérieur de votre ordinateur...
 
 **Connaissances requises**
 
-* Connaissance en C, particulièrement les pointeurs. Si le C ne vous est pas familier, vous trouverez toutes les bases dans le livre [The C Programming Language](https://en.wikipedia.org/wiki/The_C_Programming_Language).
-* Mathématiques de lycée (scalaire vs vecteur, addition, multiplication, etc...)
+* Connaissance en C, particulièrement les pointeurs. Si vous n'êtes pas familier avec le C, vous trouverez toutes les bases dans le livre [The C Programming Language](https://en.wikipedia.org/wiki/The_C_Programming_Language).
+* Mathématiques de lycée (scalaire vs vecteur, addition, multiplication, etc.)
 
 **Leçons**
 
-Dans ce répo Git se trouvent les leçons et des exercices (non inclus actuellement) relatifs à chaque leçon. A la fin de l'ensemble des leçons, vous serez capable de contribuer à FFmpeg.
+Dans ce répo Git se trouvent les leçons et des exercices (non inclus actuellement) relatifs à chaque leçon. À la fin de l'ensemble des leçons, vous serez capable de contribuer à FFmpeg.
 
 Un serveur discord est accessible pour vous apporter des réponses :
 https://discord.com/invite/Ks5MhUhqfB

--- a/lesson_01/index.fr.md
+++ b/lesson_01/index.fr.md
@@ -87,10 +87,10 @@ Ou deux quadruples mots (entiers de 64 bits):
 
 
 Pour récapituler :
-* **b**ytes - données de 8 bits
-* **w**ords - données de 16 bits
-* **d**oublewords - données de 32 bits 
-* **q**uadwords - données de 64 bits
+* **b**ytes (octets) - données de 8 bits
+* **w**ords (mots) - données de 16 bits
+* **d**oublewords (doubles mots) - données de 32 bits 
+* **q**uadwords (quadruples mots) - données de 64 bits
 * **d**ouble **q**uadwords - données de 128 bits.
 
 Les caractères en gras seront important dans la suite.

--- a/lesson_01/index.fr.md
+++ b/lesson_01/index.fr.md
@@ -54,7 +54,7 @@ Les registres sont des zones du CPU où les données peuvent être traitées. Le
 
 **Registres à usage général**
 
-Le premier type de registre que nous allons rencontrer est connu sous le nom de Registre à Usage Général (GPR). Les GPR sont appelés ainsi car ils peuvent contenir soit des données, une valeur allant jusqu'à 64-bits, soit une adresse mémoire (un pointeur). Une valeur dans un GPR peut être traitée par des opérations telles que l'addition, la multiplication, le décalage, etc.
+Le premier type de registre que nous allons rencontrer est connu sous le nom de Registre à Usage Général (GPR, *General-Purpose Register*). Les GPR sont appelés ainsi car ils peuvent contenir soit des données, une valeur allant jusqu'à 64-bits, soit une adresse mémoire (un pointeur). Une valeur dans un GPR peut être traitée par des opérations telles que l'addition, la multiplication, le décalage, etc.
 
 Dans la plupart des livres sur l'assembleur, des chapitres entiers sont concsacrés aux subtilités des GPR, leur histoire, etc. Car les GPR ont joué un rôle important dans la programmation de systèmes d'exploitation, la rétro-ingénierie (reverse engineering), etc. Dans l'assembleur écrit pour FFmpeg, les GPR sont considérés comme des échafaudages et la plupart du temps, leurs compléxités ne sont pas nécessaires et sont abstraites.
 

--- a/lesson_01/index.fr.md
+++ b/lesson_01/index.fr.md
@@ -1,39 +1,39 @@
-**FFmpeg Assembly Language Leçon Un**
+**FFmpeg Assembly Language Leçon Une**
 
 **Introduction**
 
-Bienvenue dans la FFmpeg School of Assembly Language. Vous avez fait le premier pas dans le voyage le plus intéressant, le plus stimulant et le plus gratifiant de la programmation. Ces leçons vous donneront des bases sr la façon sur la manière l'assembleur est utilisée dns FFmpeg et vous ouvriront les yeux sur ce qui se passe réellement dans votre ordinateur...
+Bienvenue dans la FFmpeg School of Assembly Language. Vous avez fait le premier pas dans le voyage le plus intéressant, le plus stimulant et le plus gratifiant de la programmation. Ces leçons vous donneront des bases sur la façon et la manière dont l'assembleur est utilisée dans FFmpeg et vous ouvriront les yeux sur ce qui se passe réellement dans votre ordinateur...
 
 **Connaissances requises**
 
-* Connaissance en C, particulièrement les pointeurs. Si le C ne vous est pas familier, vous trouverez toutes les bases dans le livre [The C Programming Language](https://en.wikipedia.org/wiki/The_C_Programming_Language).
-* Mathématiques de lycée (scalaire vs vecteur, addition, multiplication, etc...)
+* Connaissance en C, particulièrement les pointeurs. Si vous n'êtes pas familier avec le C, vous trouverez toutes les bases dans le livre [The C Programming Language](https://en.wikipedia.org/wiki/The_C_Programming_Language).
+* Mathématiques de lycée (scalaire vs vecteur, addition, multiplication, etc.)
 
 **Qu'est ce que l'assembleur?**
 
-L'assembleur est un langage de programmation où le code que vous écrivez correponds direction à des instructions compréhensible par un CPU. L'assembleur lisible par l'Homme est, comme son nom l'indique, *assemblé* en données binaires, connu sous le nom de *langage machine*, que le CPU peut comprendre. Le code assembleur est souvent appelé "assembleur" ou "asm" en ambrégé.
+L'assembleur est un langage de programmation où le code que vous écrivez correpond directement à des instructions compréhensible par un CPU. L'assembleur lisible par l'Homme est, comme son nom l'indique, *assemblé* en données binaires, connu sous le nom de *langage machine*, que le CPU peut comprendre. Le code assembleur est souvent appelé "assembleur" ou "asm" en abrégé.
 
 La grand majorité de l'assembleur de FFmpeg est ce que l'on appelle *SIMD, Single Instruction Multiple Data (instruction unique, données multiples)*. SIMD est parfois désigné sous le terme de programmation vectorielle. Cela signifie qu'une instruction particulière opère sur plusieurs éléments de données simultanément. La plupart des langages de programmation traitent un seul élément de données à la fois, ce que l'on appelle la programmation scalaire.
 
 Comme vous l'avez peut-être deviné, SIMD se prête bien au traitement d'images, des vidéos et de l'audio, qui contiennent une grande quantité de données organisées séquentiellement en mémoire. Des instructions spécialisées dans le processeur nous aideront à traiter ces données séquentielles.
 
-Dans FFmpeg, vous verrez que les termes `fonction en assembleur`, `SIMD`, `vectorisation` sont utilisés de manière interchangeable. Ils désignent tous la même chose: écrire une fonction en assembleur à la main pour traiter plusieurs éléments de données en une seule fois. Certains projets peuvent aussi faire référence à des `noyaux en assembleur`.
+Dans FFmpeg, vous verrez que les termes `fonction en assembleur`, `SIMD` et `vectorisation` sont utilisés de manière interchangeable. Ils désignent tous la même chose : écrire une fonction en assembleur à la main pour traiter plusieurs éléments de données en une seule fois. Certains projets peuvent aussi faire référence à des `noyaux en assembleur`.
 
-Tout cela peut sembler compliqué, mais il est important de rappeler que des lycééns ont écrit de l'assembleur dans FFmpeg. Comme partout, l'apprentissage c'est 50% du jargon et 50% d'apprentissage réel.
+Tout cela peut sembler compliqué, mais il est important de rappeler que des lycéens ont écrit de l'assembleur dans FFmpeg. Comme partout, l'apprentissage c'est 50% du jargon et 50% d'apprentissage réel.
 
-**Pourquoi écrivons en assembleur ?**
+**Pourquoi écrivons-nous en assembleur ?**
 
 Pour rendre le traitement multimédia rapide. Il est très courant d'avoir une vitesse de traitement au moins 10 fois plus rapide en écrivant en assembleur, ce qui est d'autant plus important quand nous voulons lire des vidéos en temps réel sans saccade. Cela permet aussi d'économiser de l'énergie et d'étendre la durée de vie des batteries. Il est important de souligner que les fonctions d'encodage et de décodage sont parmi les fonctions les plus utilisés au monde, aussi bien par les utilisateurs finaux que par les multi-nationales dans leurs data-centers. Donc, même une petit amélioration apporte beaucoup.
 
 Vous verrez souvent, en ligne, des gens utiliser des *fonctions intrinsèques*, des fonctions ressemblants à du C mais qui sont en fait des instructions en assembleur utilisées pour pemettre un développement plus rapide. Dans FFmpeg, nous n'utilisons pas ce genre de fonctions, nous écrivons tout le code en assembleur à la main. C'est un point de discorde, mais les fonctions intrinsèques sont environ 10 à 15% plus lente que l'équivalent en assembleur écrit à la main (les partisans de ces fonctions ne seraient pas d'accord), tout dépend du compilateur. Pour FFmpeg, chaque amélioration compte, c'est pourquoi nous écrivons tout le code directement en assembleur. Un argument en notre faveur est l'utilisation de la `[notation hongroise](https://fr.wikipedia.org/wiki/Notation_hongroise)` dans les fonctions intrinsèques qui compliquent leur lecture.
 
-Aussi, vous verrez des référence à de l'*assembleur en ligne* (ou *assembleur inline*), c'est-à-dire n'utilisant pas de fonctions intrinsèques, à quelques endroits dans FFmpeg pour des raisons historiques, ou dans des projets comme le noyau Linux dans des scénarios d'utilisations très spécifiques. Ici, le code assembleur n'est pas dans un fichier séparé mais écrit directement dans des fichiers avec du code en C. Le point de vue majoritaire dans des projets comme FFmpeg est que ce code est difficile à lire, pas largement supporté par les compilateurs et difficile à maintenir.
+Aussi, vous verrez des références à de l'*assembleur en ligne* (ou *assembleur inline*), c'est-à-dire n'utilisant pas de fonctions intrinsèques, à quelques endroits dans FFmpeg pour des raisons historiques, ou dans des projets comme le noyau Linux dans des scénarios d'utilisations très spécifiques. Ici, le code assembleur n'est pas dans un fichier séparé mais écrit directement dans des fichiers avec du code en C. Le point de vue majoritaire dans des projets comme FFmpeg est que ce code est difficile à lire, mal supporté par les compilateurs et difficile à maintenir.
 
 Enfin, vous verrez beaucou d'experts auto-proclamés sur Internet disant que rien de tout cela est nécessaire et que le compilateur peut effectuer cette `vectorisation` pour vous. Dans une optique d'apprentissage, ignorez-les : des tests récents comme ceux présents sur le [projet dav1d](https://www.videolan.org/projects/dav1d.html) ont montrés un gain de vitesse d'environ x2 grâce à cette vectorisation automatique, tandis que pour des versions écrites à la main, ce gain montait à x8.
 
 **Les variétés d'assembleurs**
 
-Ces leçons se concentreront sur l'assembleur x86 64 bits. Aussi connu sous le nom d'amd64, bien qu'il continue de fonctionner sur les CPUs Intel. Il existe autant de types d'assembleurs que de CPUs comme ceux pour ARM ou RISC-V avec potentiellement des mises à jour de ces cours pour les inclure.
+Ces leçons se concentreront sur l'assembleur x86_64 bits. Aussi connu sous le nom d'amd64, bien qu'il fonctionne aussi sur les CPUs Intel. Il existe autant de types d'assembleurs que de CPUs comme ceux pour ARM ou RISC-V avec potentiellement des mises à jour de ces cours pour les inclure.
 
 Il existe deux types de syntaxes pour l'assembleur x86 que vous trouverez en ligne : AT&T et Intel. La première est plus ancienne et plus difficile à lire comparé à la seconde. Nous nous intéresserons à cette dernière.
 
@@ -43,9 +43,9 @@ Vous serez peut-être surpris d'entendre que des livres ou des ressources en lig
 
 Beaucoup de livres détaillent beaucoup différentes architectures d'ordinateur avant de détailler l'assembleur. De notre point de vue, c'est très bien si c'est ce que vous voulez apprendre, mais cela revient à vouloir étudier les moteurs avant d'apprendre à conduire une voiture.
 
-Une fois ceci dit, dans les parties suivantes, les diagrammes du livre `The Art of 64-bit assembly` montrant les instructions SIMD et leur comportement sous forme visuelle vous seront très utiles : [https://artofasm.randallhyde.com/](https://artofasm.randallhyde.com/)
+Ceci dit, dans les parties suivantes, les diagrammes du livre `The Art of 64-bit assembly` montrant les instructions SIMD et leur comportement sous forme visuelle vous seront très utiles : [https://artofasm.randallhyde.com/](https://artofasm.randallhyde.com/)
 
-Un serveur Discord est disponible pour répondre à vos questions:
+Un serveur Discord est disponible pour répondre à vos questions :
 [https://discord.com/invite/Ks5MhUhqfB](https://discord.com/invite/Ks5MhUhqfB)
 
 **Les registres**  
@@ -54,19 +54,19 @@ Les registres sont des zones du CPU où les données peuvent être traitées. Le
 
 **Registres à usage général**
 
-Le premier type de registre que nous allons rencontrer est connu sous le nom de Registre à Usage Générale (GPR). Les GPR sont appelés ainsi car ils peuvent contenir soit des données, une valeur allant jusqu'à 64-bits, soit une adresse mémoire (un pointeur). Une valeur dans un GPR peut être traitée par des opérations telles que l'addition, la multiplication, le décalage, etc...
+Le premier type de registre que nous allons rencontrer est connu sous le nom de Registre à Usage Général (GPR). Les GPR sont appelés ainsi car ils peuvent contenir soit des données, une valeur allant jusqu'à 64-bits, soit une adresse mémoire (un pointeur). Une valeur dans un GPR peut être traitée par des opérations telles que l'addition, la multiplication, le décalage, etc.
 
-Dans la plupart des livres sur l'assembleur, de nombreux chapitres entiers sont concsacrés aux subtilités des GPR, leur histoire, etc... Car les GPR ont joués un rôle important dans la programmation de systèmes d'exploitation, le reverse engineering, etc... Dans l'assembleur écrit pour FFmpeg, les GPR sont considérés comme des échafaudages et la plupart du temps, leur compléxités ne sont pas nécessaires et sont abstraites.
+Dans la plupart des livres sur l'assembleur, des chapitres entiers sont concsacrés aux subtilités des GPR, leur histoire, etc. Car les GPR ont joué un rôle important dans la programmation de systèmes d'exploitation, la rétro-ingénierie (reverse engineering), etc. Dans l'assembleur écrit pour FFmpeg, les GPR sont considérés comme des échafaudages et la plupart du temps, leurs compléxités ne sont pas nécessaires et sont abstraites.
 
 **Registres vectoriels**  
-Les registrs vectoriels (SIMD), comme leur nom le suggère, contiennent plusieurs éléments de données. Il existe différents types de registres vectoriels:
+Les registrs vectoriels (SIMD), comme leur nom le suggère, contiennent plusieurs éléments de données. Il existe différents types de registres vectoriels :
 
 * registres `mm` : des registres `MMX`, de taille 64-bits, historique et peu utilisés de nos jours
-* registres `xmm` : des registres `XMM`, de taille 128 bits, largement disponible
-* registres `ymm` : des registres `YMM`, de tailles 256 bits, avec quelques complications lors de leur utilisation
-* registres `zmm` : des registres `ZMM`, de tailles 512 bits, très peu disponible
+* registres `xmm` : des registres `XMM`, de taille 128 bits, largement disponibles
+* registres `ymm` : des registres `YMM`, de taille 256 bits, avec quelques complications lors de leur utilisation
+* registres `zmm` : des registres `ZMM`, de taille 512 bits, très peu disponibles
 
-La plupart des calculs de compression et de décompression vidéo sont basés sur des entiers, nous nous y limiterons. Voici un exemple d'un registre `XMM` de 16 octets:
+La plupart des calculs de compression et de décompression vidéo sont basés sur des entiers, nous nous y limiterons. Voici un exemple d'un registre `XMM` de 16 octets :
 
 | a | b | c | d | e | f | g | h | i | j | k | l | m | n | o | p |
 | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
@@ -142,7 +142,7 @@ Passons en revue le code ligne par ligne :
 %include "x86inc.asm"
 ```
 
-Ce `header` développé dans les communautés x264, FFmpeg et dav1d pour fournir des axiliaires, des noms prédéfinis et des macros (comme `cglobal` ci-dessous) pour simpliflier l'écriture du code assembleur.
+C'est un `header` développé dans les communautés x264, FFmpeg et dav1d pour fournir des axiliaires, des noms prédéfinis et des macros (comme `cglobal` ci-dessous) pour simpliflier l'écriture du code assembleur.
 
 ```assembly
 SECTION .text
@@ -169,7 +169,7 @@ Passons en revue chaque élément de la ligne un par un :
 * Le paramètre suivant indique à x86util combien de registres `XMM` nous allons utiliser.
 * Les deux derniers paramètres sont les labels utilisés pour les arguments de la fonction `add_values`.
 
-Il est important de noter que le code plus ancien peut ne pas avoir les labels comme arguments de fonctions mais plutôt les adresses des registres GPR à la place, en utilisant `r0`, `r1`, etc...
+Il est important de noter que le code plus ancien peut ne pas avoir les labels comme arguments de fonctions mais plutôt les adresses des registres GPR à la place, en utilisant `r0`, `r1`, etc.
 
 ```assembly
     movu  m0, [srcq]  

--- a/lesson_01/index.fr.md
+++ b/lesson_01/index.fr.md
@@ -123,7 +123,7 @@ Voici notre première fonction SIMD :
 
 SECTION .text
 
-;static void add_values(const uint8_t *src, const uint8_t *src2)  
+;static void add_values(uint8_t *src, const uint8_t *src2)  
 INIT_XMM sse2  
 cglobal add_values, 2, 2, 2, src, src2   
     movu  m0, [srcq]  
@@ -150,7 +150,7 @@ SECTION .text
 Cela désigne la section où le code que vous voulez exécuter est placé. Cela contraste avec la section `.data`, où vous pouvez placer des données constantes.
 
 ```assembly
-;static void add_values(const uint8_t *src, const uint8_t *src2);  
+;static void add_values(uint8_t *src, const uint8_t *src2);  
 INIT_XMM sse2
 ```
 

--- a/lesson_02/index.fr.md
+++ b/lesson_02/index.fr.md
@@ -11,7 +11,7 @@ mov  r0q, 3
     jmp .loop
 ```
 
-L'instruction `jmp` déplace l'exécution du code après `.loop:`. `.loop:` est ce qu'on appelle un **label**. Le **point** (.) préfixant le label indique que ce label est un **label local**. Cela signifie que vous pouvez réutiliser le même nom de label dans plusieurs fonctions sans provoque de conflits.
+L'instruction `jmp` déplace l'exécution du code après `.loop:`. `.loop:` est ce qu'on appelle un **label**. Le **point** (.) préfixant le label indique que ce label est un **label local**. Cela signifie que vous pouvez réutiliser le même nom de label dans plusieurs fonctions sans provoquer de conflits.
 
 Cette portion de code est un exemple de boucle infinie, nous l'améliorerons dans la suite des leçons pour avoir un exemple beaucoup plus réaliste.
 
@@ -47,7 +47,7 @@ for(i = 0; i < 3; i++) {
 }
 ```
 
-Les deux exemples sont quasiment équivalents à la portion en assembleur suivante (il n'y a pas de manière simple de trouver l'équivalent à cette boucle ```for```):
+Les deux exemples sont quasiment équivalents à la portion en assembleur suivante (il n'y a pas de manière simple de trouver l'équivalent à cette boucle ```for```) :
 
 ```assembly
 xor r0q, r0q
@@ -58,10 +58,10 @@ xor r0q, r0q
     jl  .loop ; jump if (r0q - 3) < 0, i.e (r0q < 3)
 ```
 
-Plusieurs choses sont à examiner sur cette extrait de code. Dans un premier temps, ```xor r0q, r0q``` est une manière simple d'assigner un registre à zéro, ce qui est plus rapide sur certains système que ```mov r0q, 0```, parce qu'il n'y a aucun chargement de registres.
-Cela peut aussi être utilisé avec des registres **SIMD** avec la ligne ```pxor m0, m0``` pour mettre à zéro un registre entier. La chose suivante à noter est l'utilisation de ```cmp```. ```cmp``` peut effectivement soustraier le second registre du premier (sans avoir à sauvegarder la valeur quelque part) et met jour les *FLAGS*, mais comme l'indique le commentaire, cela peut être lu avec l'instruction de saut ```jl``` (saut si inférieur à zéro) pour effctuer un sat si ```r0q < 3```.
+Plusieurs choses sont à examiner sur cet extrait de code. Dans un premier temps, ```xor r0q, r0q``` est une manière simple d'assigner un registre à zéro, ce qui est plus rapide sur certains système que ```mov r0q, 0```, parce qu'il n'y a aucun chargement de registres.
+Cela peut aussi être utilisé avec des registres **SIMD** avec la ligne ```pxor m0, m0``` pour mettre à zéro un registre entier. La chose suivante à noter est l'utilisation de ```cmp```. ```cmp``` peut effectivement soustraire le second registre du premier (sans avoir à sauvegarder la valeur quelque part) et mettre à jour les *FLAGS*, mais comme l'indique le commentaire, cela peut être lu avec l'instruction de saut ```jl``` (saut si inférieur à zéro) pour effctuer un sat si ```r0q < 3```.
 
-Notez la présence d'une instruction supplémentaire (````cmp```) dans ce court extrait. Généralement, peu d'instructions équivaut à du code plus rapide, c'est pourquoi l'exemple précédent est préféré. Comme vous le verrez plus tard, il existe plusieurs astuces pour éviter des instructions supplémentaires et faire en sort que les *FLAGS* soient définis par une opération arithmétique ou une autre opération. Notez que nous n'écrivons pas de l'assembleur pour correspondre exactement aux boucles en C, nous écrivons des boucles en assembleur pour les rendre les plus rapide en assembleur.
+Notez la présence d'une instruction supplémentaire (````cmp```) dans ce court extrait. Généralement, moins d'instructions équivaut à du code plus rapide, c'est pourquoi l'exemple précédent est préféré. Comme vous le verrez plus tard, il existe plusieurs astuces pour éviter des instructions supplémentaires et faire en sort que les *FLAGS* soient définis par une opération arithmétique ou une autre opération. Notez que nous n'écrivons pas de l'assembleur pour correspondre exactement aux boucles en C, nous écrivons des boucles en assembleur pour les rendre les plus rapide en assembleur.
 
 Voici quelques mnémoniques de saut que vous finirez par utiliser (les registres *FLAGS* sont présentés là pour tout couvrir, mais vous n'aurez pas à connaître pour écrire des boucles) :
 
@@ -76,7 +76,7 @@ Voici quelques mnémoniques de saut que vous finirez par utiliser (les registres
 
 **Constantes**
 
-Plongeons dans quelques exemples sur l'utilisation des constantes:
+Plongeons dans quelques exemples sur l'utilisation des constantes :
 
 ```assembly
 SECTION_RODATA
@@ -85,17 +85,17 @@ constants_1: db 1,2,3,4
 constants_2: times 2 dw 4,3,2,1
 ```
 
-* SECTION_RODATA indique qu'il s'agit d'une section en lecture seule. (C'est une macro car les différents formats de fichier de sortie utilisés par les systèmes d'exploitation les déclare différemment.)
+* SECTION_RODATA indique qu'il s'agit d'une section en lecture seule. (C'est une macro car les différents formats de fichier de sortie utilisés par les systèmes d'exploitation les déclarent différemment.)
 * le label *constants_1* est défini comme étant un ```db``` (*declared bytes*), c'est équivalent à uint8_t constants_1[4] = {1, 2, 3, 4};
 * constants_2 utilise la macro ```times 2``` pour répété la définition de mot (```dw``` pour *declared word*), c'est équivalent à uint16_t constants_2[8] = {4, 3, 2, 1, 4, 3, 2, 1};
 
-Ces labels, que l'assembleur convertit en addresse mémoire, peuvent être utiliser pour les chargements (mais pas pour des stockages car ils sont en lecture seule). Quelques instructions acceptent une addresse mémoire comme opérande, ce qui permet de les utiliser sans chargement explicite dans un registre (il y a des avantages et des inconvénients à ceci).
+Ces labels, que l'assembleur convertit en adresse mémoire, peuvent être utilisés pour les chargements (mais pas pour des stockages car ils sont en lecture seule). Quelques instructions acceptent une adresse mémoire comme opérande, ce qui permet de les utiliser sans chargement explicite dans un registre (il y a des avantages et des inconvénients à ceci).
 
 **Offsets (déplacements)**
 
 Les offsets (*déplacements*) sont les distances (en bytes) entre deux éléments consécutifs en mémoire. L'offset est déterminé par la **taille de chaque élément** dans la structure de donnée.
 
-Maintenant que nous sommes capables d'écrire des boucles, il est temps de récupérer des données. Mais il existe des différences par rapport au C. Regardons la boucle suivante en C:
+Maintenant que nous sommes capables d'écrire des boucles, il est temps de récupérer des données. Mais il existe des différences par rapport au C. Regardons la boucle suivante en C :
 
 ```c
 uint32_t data[3];
@@ -105,9 +105,9 @@ for(i = 0; i < 3; i++) {
 }
 ```
 
-L'offset de 4 vytes entre chaque élément de données est pré-calculé par le compilateur. Mais en l'écrivant à la main en assembleur, vous devrez calculer cet offset vous-même.
+L'offset de 4 bytes entre chaque élément de données est pré-calculé par le compilateur. Mais en l'écrivant à la main en assembleur, vous devrez calculer cet offset vous-même.
 
-Regardons à la syntaxe du calcul des addresses mémoires. Cela s'applique à tout type d'addresses mémoires:
+Regardons maintenant la syntaxe du calcul des adresses mémoires. Cela s'applique à tous types d'adresses mémoires :
 
 ```assembly
 [base + scale*index + disp]
@@ -120,7 +120,7 @@ Regardons à la syntaxe du calcul des addresses mémoires. Cela s'applique à to
 
 x86asm fournit la constante **mmsize**, qui vous indique la taille du registre SIMD avec leque vous travaillez.
 
-Voici un simple (et pas très logique) exemple d'illustratio du chargement avec des déplacements différents:
+Voici un exemple simple (et pas très logique) d'illustration du chargement avec des déplacements différents :
 
 ```assembly
 ;static void simple_loop(const uint8_t *src)
@@ -144,19 +144,19 @@ Notez comment dans  ```movu m1, [srcq+2*r1q+3+mmsize]```  l'assemble pré-calcul
 
 **LEA**
 
-Maintenant que vous maitrisez les offsets, vous êtes capable d'utiliser l'instruction ```lea``` (_**L**oad **E**ffective **A**ddress*_). Avec une seule instruction, vous êtes capable de faire une mumtiplication et une addition, ce qui est alors plus rapide que l'utilisation de plusieurs instructions. Il y a, bien sûr, des limitations sur les données que vous pouvez multiplier et ajouter mais cela n'empêche pas ```lea``` d'être une instruction puissante.
+Maintenant que vous maitrisez les offsets, vous êtes capable d'utiliser l'instruction ```lea``` (_**L**oad **E**ffective **A**ddress*_). Avec une seule instruction, vous êtes capable de faire une multiplication et une addition, ce qui est alors plus rapide que l'utilisation de plusieurs instructions. Il y a, bien sûr, des limitations sur les données que vous pouvez multiplier et ajouter mais cela n'empêche pas ```lea``` d'être une instruction puissante.
 
 ```assembly
 lea r0q, [base + scale*index + disp]
 ```
 
-Contrairement à son nom, **LEA** peut être utilisée autant pour des opérations arithmétiques que pour des calculs d'addresses mémoires. Vous pouvez faire quelque chose d'aussi compliqué que:
+Contrairement à son nom, **LEA** peut être utilisée autant pour des opérations arithmétiques que pour des calculs d'adresses mémoires. Vous pouvez faire quelque chose d'aussi compliqué que :
 
 ```assembly
 lea r0q, [r1q + 8*r2q + 5]
 ```
 
-Il est important de noter que cela n'affecte par le contenu de ````r1q``` et ```r2q```. Cela n'impacte pas non plus les registres *FLAGS* (par conséquent, vous ne pouvez pas effectuer de saut sur la sortie). L'utilisation des **LEA** évite toutes ces instructions et les régistres temporaires (ce code n'a pas d'équivalent car ```add``` modifie les *FLAGS*):
+Il est important de noter que cela n'affecte par le contenu de ```r1q``` et ```r2q```. Cela n'impacte pas non plus les registres *FLAGS* (par conséquent, vous ne pouvez pas effectuer de saut sur la sortie). L'utilisation des **LEA** évite toutes ces instructions et les registres temporaires (ce code n'a pas d'équivalent car ```add``` modifie les *FLAGS*) :
 
 ```assembly
 movq r0q, r1q
@@ -166,7 +166,7 @@ add  r3q, 5
 add  r0q, r3q
 ```
 
-Vous verrez l'utilisation de ```lea``` dans l'utilisation de beaucoup d'addresses avant des boulces ou pour faire des calculs comme le précédent. Notez bien, que vous ne pouvez pas faire tous types de multiplications et d'additions, mais les multiplications par 1, 2, 4 ou 8 et les additions d'un décalage fixe sont des opérations courantes.
+Vous verrez souvent ```lea``` utilisé pour paramétrer des adresses avant des boucles ou pour faire des calculs comme le précédent. Notez bien, que vous ne pouvez pas faire tous types de multiplications et d'additions, mais les multiplications par 1, 2, 4 ou 8 et les additions d'un décalage fixe sont des opérations courantes.
 
 Dans l'exercice, vous aurez à charger une constante et en addiioner les valeurs à un vecteur **SIMD** dans une boucle.
 

--- a/lesson_03/index.fr.md
+++ b/lesson_03/index.fr.md
@@ -4,28 +4,28 @@ Expliquons un peu plus de jargon et lisez bien cette petite leçon d'histoire.
 
 **Jeux d'instructions**
 
-Vous avez surêment prêté attention au fait que dans la leçon précédente, noud avons parlé de **SSE2** qui fait parti du jeu d'instructions **SIMD**. Quand une nouvelle génération de CPU sort sur le marché, elle peut être accompagnée de nouvelles instructions et quelques fois des registres de tailles plus grandes. L'histoire du jeu d'instruction x86 est tellement complexe qu'il en existe une version simplifiée (avec plusieurs sous histoires dans celle-ci):
+Vous avez sûrement prêté attention au fait que dans la leçon précédente, nous avons parlé de **SSE2** qui fait parti du jeu d'instructions **SIMD**. Quand une nouvelle génération de CPU sort sur le marché, elle peut être accompagnée de nouvelles instructions et quelques fois des registres de tailles plus grandes. L'histoire du jeu d'instruction x86 est tellement complexe qu'il en existe une version simplifiée (avec plusieurs sous histoires dans celle-ci) :
 
 * MMX - Lancée en 1997, la première version **SIMD** chez Intel Processors, registres de 64 bits, version historique.
 * SSE (Streaming SIMD Extensions) - Lancée en 1999, registres de 128 bits.
 * SSE2 - Lancée en 2000, plusieurs nouvelles instructions.
 * SSE3 - Lancée en 2004, premières instructions *horizontales*.
 * SSSE3 (Supplemental SSE3) - Lancée en 2006, ajout de nouvelles instructions dont la plus importante ```pshufb```, sans doute l'instruction la plus importante pour le traitement vidéo
-* SSE4 - Launchée en 2008, ajout de nombreuses nouvelles instructions, notamment les minimums et maximums en mode vectorisé.
-* AVX - Launchée en 2011, ajout de registres à 256 bits (uniquement pour les flottants) et d'une nouvelle syntaxe à trois opérandes.
-* AVX2 - Launchée en 2013, ajout de registres à 256 bits pour les registres pour les instructions entières.
+* SSE4 - Lancée en 2008, ajout de nombreuses nouvelles instructions, notamment les minimums et maximums en mode vectorisé.
+* AVX - Lancée en 2011, ajout de registres à 256 bits (uniquement pour les flottants) et d'une nouvelle syntaxe à trois opérandes.
+* AVX2 - Lancée en 2013, ajout de registres à 256 bits pour les registres pour les instructions entières.
 * AVX512 - Lancée en 2017, registres à 512 bits, nouvelle instruction de masquage. Leur utilisation dans FFmpeg était très limitée en raison de la diminution de la fréquence du CPU quand de nouvelles instructions étaient utilisées. Permutation complète de 512 bits avec ```vpermb```.
-* AVX512ICL - Lancé en 2019, suppression de la réduction de fréquence du processeur.
-* AVX10 - A venir.
+* AVX512ICL - Lancée en 2019, suppression de la réduction de fréquence du processeur.
+* AVX10 - À venir.
 
 Il est important de noter que des jeux d'instructions peuvent être supprimés ou ajoutés d'un CPU à l'autre. Par exemple, **AVX512** a été [supprimé](https://www.igorslab.de/en/intel-deactivated-avx-512-on-alder-lake-but-fully-questionable-interpretation-of-efficiency-news-editorial/), de manière controversé, dans la 12ème génération de CPU Intel. C'est pour cette raison que FFmpeg fait de la détection du CPU à l'exécution. FFmpeg détecte les capacités du processeur sur lequel il s'exécute.
 
-Comme vous l'avez vu dans l'exercice, les pointeurs de fonctions sont par défaut en **C** et sont remplacées par un jeu d'instruction particulier. Cela signifie que la détection est réalisée une fois et ne sera plus jamais requise. Cela contraste avec beaucoup d'applications propriétaires qui programment en dur dans leur code un jeu d'instruction rendant obsolète des ordinateurs parfaitement fonctionnels. Cela permet aussi d'activer ou de désactuver des fonctions optimisées à l'exécution. C'est l'un des plus grands avantages de l'open source.
+Comme vous l'avez vu dans l'exercice, les pointeurs de fonctions sont par défaut en **C** et sont remplacées par un jeu d'instruction particulier. Cela signifie que la détection est réalisée une fois et ne sera plus jamais requise. Cela contraste avec beaucoup d'applications propriétaires qui programment en dur dans leur code un jeu d'instruction rendant obsolète des ordinateurs parfaitement fonctionnels. Cela permet aussi d'activer ou de désactiver des fonctions optimisées à l'exécution. C'est l'un des plus grands avantages de l'open source.
 
-Des programmes comme FFmpeg sont utilisés par des milliards d'appareils autour du monde, certains d'entre eux sont peut-être très agés. Techniquement, FFmpeg est compatible avec des machines possédant uniquement le jeu d'instruction **SSE**, machines qui datent d'il y a 25 ans.
-Heureusement, **x86inc.ams** est captable de vous indiquer si une instruction n'est pas disponible dans un jeu d'instruction particulier.
+Des programmes comme FFmpeg sont utilisés par des milliards d'appareils autour du monde, certains d'entre eux sont peut-être très âgés. Techniquement, FFmpeg est compatible avec des machines possédant uniquement le jeu d'instruction **SSE**, machines qui datent d'il y a 25 ans.
+Heureusement, **x86inc.asm** est capable de vous indiquer si une instruction n'est pas disponible dans un jeu d'instruction particulier.
 
-Pour vous donner une idée des compatibilités, voici la disponibilité des jeux d'instructions selon le [Steam Survey](https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam) en novembre 2024 (évidemment biaisé en faveur des joueurs):
+Pour vous donner une idée des compatibilités, voici la disponibilité des jeux d'instructions selon le [Steam Survey](https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam) en novembre 2024 (évidemment biaisé en faveur des joueurs) :
 
 | Jeu d'instruction | Disponibilité |
 | :---- | :---- |
@@ -37,13 +37,13 @@ Pour vous donner une idée des compatibilités, voici la disponibilité des jeux
 | AVX2 | 94.44% |
 | AVX512 (AVX512 et AVX512ICL confondus) | 14.09% |
 
-Pour une application comme FFmpeg avec des milliards d'utilisateurs, même 0.1% d'entre eux représent un grand nombre d'utilisateurs et de rapports de bug en cas de problème. FFmpeg possède une grande infrastructure de tests pour tester chaque combinaison de CPU/ OS / compilateurs présentée sur [FATE testsuite](https://fate.ffmpeg.org/?query=subarch:x86_64%2F%2F). Chaque simple commit est exécuté sur des centaines de machines pour être certain que rien ne casse.
+Pour une application comme FFmpeg avec des milliards d'utilisateurs, même 0.1% d'entre eux représentent un grand nombre d'utilisateurs et de rapports de bug en cas de problème. FFmpeg possède une grande infrastructure de tests pour tester chaque combinaison de CPU/ OS / compilateurs présentée sur [FATE testsuite](https://fate.ffmpeg.org/?query=subarch:x86_64%2F%2F). Chaque simple commit est exécuté sur des centaines de machines pour être certain que rien ne casse.
 
-Inter fournit un manuel de jeu d'instruction détaillé ici: [https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)
+Intel fournit un manuel de jeu d'instruction détaillé ici : [https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)
 
-Cela peut être laborieux de chercher sur un PDF, une alternative en ligne est présente ici: [https://www.felixcloutier.com/x86/](https://www.felixcloutier.com/x86/)
+Cela peut être laborieux de chercher sur un PDF, une alternative en ligne est présente ici : [https://www.felixcloutier.com/x86/](https://www.felixcloutier.com/x86/)
 
-Il y a aussi une représentation visuelle des instructions SIMD disponible ici: [https://www.officedaytime.com/simd512e/](https://www.officedaytime.com/simd512e/)
+Il y a aussi une représentation visuelle des instructions SIMD disponible ici : [https://www.officedaytime.com/simd512e/](https://www.officedaytime.com/simd512e/)
 
 Une partie du défi de l'utilsation de l'assembleur x86 est de trouver la bonne instruction dont vous avez besoin. Dans certains cas, des instructions peuvent être utilisées dans des cas de figure pour lesquelles elles n'ont pas été faites originellement.
 
@@ -118,7 +118,7 @@ Notez que cela aligne uniquement le début de la section RODATA. Des octets de r
 
 Un autre sujet que nous avons évité jusqu'à présent est le débordement. Cela se produit, par exemple, lorsque la valeur d'un octet dépasse 255 après une opération comme l'addition ou la multiplication. Nous pouvons vouloir effectuer une opération où nous avons besoin d'une valeur intermédiaire plus grande qu'un octet (par exemple, des mots), ou potentiellement nous voulons laisser les données dans cette taille intermédiaire plus grande.
 
-Pour les octets non signés, c'est là que les instructions `punpcklbw` (décompacter des octets en mots dans le bas d'un paquets) et `punpckhbw` (décompacter des octets en mots dans le haut d'un paquets) interviennent.
+Pour les octets non signés, c'est là que les instructions `punpcklbw` (décompacter des octets en mots dans le bas d'un paquet) et `punpckhbw` (décompacter des octets en mots dans le haut d'un paquet) interviennent.
 
 Voyons comment fonctionne `punpcklbw`. La syntaxe pour la version SSE2 dans le manuel Intel est la suivante :
 
@@ -131,7 +131,7 @@ Le site web officedaytime.com ci-dessus a un bon diagramme montrant ce qui se pa
 
 ![What is this](image1.png)
 
-Vous pouvez voir que les octets sont entrelacés à partir de la moitié inférieure de chaque registre respectivement. Mais quel rapport cela a-t-il avec l'extension de plage ? Si le registre source est entièrement nul, cela entrelace les octets dans le registre de destination avec des zéros. C'est ce qu'on appelle l'*extension par zéro*, car les octets sont sans signe. punpckhbw peut être utilisé pour faire la même chose pour les octets supérieurs.
+Vous pouvez voir que les octets sont entrelacés à partir de la moitié inférieure de chaque registre respectivement. Mais quel rapport cela a-t-il avec l'extension de plage ? Si le registre source est entièrement nul, cela entrelace les octets dans le registre de destination avec des zéros. C'est ce qu'on appelle l'*extension par zéro*, car les octets sont sans signe. `punpckhbw` peut être utilisé pour faire la même chose pour les octets supérieurs.
 
 Voici un extrait montrant comment cela est fait :
 
@@ -184,7 +184,7 @@ for(int i = 0; i < 16; i++) {
 }
 ```
 
-Voici un exemple simple en assembleur:
+Voici un exemple simple en assembleur :
 
 ```assembly
 SECTION_DATA 64

--- a/lesson_03/index.fr.md
+++ b/lesson_03/index.fr.md
@@ -56,7 +56,7 @@ Nous utilisons `ptrdiff_t` pour la variable de largeur au lieu de `int` afin de 
 La fonction ci-dessous contient l’astuce des décalages de pointeur :
 
 ```assembly
-;static void add_values(const uint8_t *src, const uint8_t *src2, ptrdiff_t width)
+;static void add_values(uint8_t *src, const uint8_t *src2, ptrdiff_t width)
 INIT_XMM sse2
 cglobal add_values, 3, 3, 2, src, src2, width
    add srcq, widthq


### PR DESCRIPTION
## Corrige différentes erreurs dans README et lesson_01 : 

### Dans le README.fr.md :
* Petites fautes de frappe
* Répétition de mots
* Tournures de phrase
* Change "etc..." -> "etc." Car les points de suspension et etc. ont la même fonction donc il ne faut pas les mettre tous les deux [Et cetera - Wikipédia](https://fr.wikipedia.org/wiki/Et_cetera)
* Change "A" -> "À"
* Ajout d'espaces avant les ponctuations doubles (*: ; ? !*), « `exemple :` » au lieu de « `exemple:` ». 

### Dans Lesson_01/index.fr.md : 
* Comme README.fr.md
* Ajoute des traductions française pour byte (octet) et word (mot), double-word (double mot), etc. (*commit séparé*)
* Corrige l'en-tête de fonction C qui diffère de la version anglaise, voir le [commit `ad625c5`](https://github.com/FFmpeg/asm-lessons/commit/ad625c517ad5eb88fe4ebaf7318618140152906b). 

### Erreurs courantes remarquées : 
* Absence d'espace avant les ponctuations doubles (surtout `:`)
* Mauvaise traduction de « address », le mot en français ne prend qu'un D : « adresse » et non « addresse ». 

**À noter que je n'ai pas d'expérience en assembleur, je n'ai pas touché à cette partie, seulement vérifié son intégrité par rapport à la version anglaise.** 
